### PR TITLE
DO NOT merge

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,9 +4,9 @@ class SessionsController < ApplicationController
       flash[:logged_in] = "You are already logged in."
       case current_user.role
       when 'registered'
-        redirect_to profile_path(current_user)
+        redirect_to profile_path
       when 'merchant'
-        redirect_to "/dashboard/#{current_user.id}"
+        redirect_to "/dashboard"
       when 'admin'
         redirect_to root_path
       end
@@ -19,9 +19,9 @@ class SessionsController < ApplicationController
       session[:user_id] = user.id
       flash[:success] = "Welcome, #{user.name}"
       if user.registered?
-        redirect_to profile_path(user)
+        redirect_to profile_path
       elsif user.merchant?
-        redirect_to "/dashboard/#{user.id}"
+        redirect_to "/dashboard"
       elsif user.admin?
         redirect_to root_path
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = current_user
   end
 
   def edit

--- a/app/views/_navbar.html.erb
+++ b/app/views/_navbar.html.erb
@@ -8,13 +8,13 @@
       <li><h3><%= link_to "Merchants", "/merchants" %></h3></li>
 
       <% if current_user && current_user.merchant? %>
-        <li><h3><%= link_to "Dashboard", "/dashboard/#{current_user.id}" %></h3></li>
+        <li><h3><%= link_to "Dashboard", "/dashboard" %></h3></li>
       <% elsif current_user && current_user.admin? %>
         <li><h3><%= link_to "All Users", "/admin/users" %></h3></li>
       <% end %>
       <% if current_user %>
-        <li><h3><%= link_to "Profile", profile_path(current_user.id) %></h3></li>
-        <li><h3><%= link_to "Orders", user_orders_path(current_user.id) %></h3></li>
+        <li><h3><%= link_to "Profile", profile_path %></h3></li>
+        <li><h3><%= link_to "Orders", profile_orders_path %></h3></li>
         <li><h3><%= link_to "Log Out", logout_path, method: :delete %></h3></li>
         <li><h3>Logged in as <%= current_user.name %></h3></li>
       <% else %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,4 +5,10 @@
 <%= @user.state %>
 <%= @user.zip_code %>
 
-<%= link_to 'Edit Profile', edit_user_path(@user) %>
+<% if current_user && current_user.registered? %>
+  <%= link_to 'Edit Profile', edit_user_path(@user) %>
+<% end %>
+
+<% if current_user && current_user.merchant? %>
+  <%= link_to 'View Items', "/dashboard/items"%>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,16 +12,18 @@ Rails.application.routes.draw do
   resources :carts, only: [:create]
 
   resources :users, only: [:index, :create, :edit] do
-    resources :orders, only: [:index]
+    # resources :orders, only: [:index]
   end
 
 
-  get '/profile/:id', to: 'users#show', as: :profile
+  get '/profile', to: 'users#show'
   get '/profile/orders', to: 'orders#index'
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
-  get '/dashboard/:id', to: 'users#show'
+  get '/dashboard', to: 'users#show'
+  get '/dashboard/items', to: 'users#index'
+
   get '/register', to: 'users#new'
   get '/merchants', to: 'users#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,11 +10,9 @@ Rails.application.routes.draw do
   end
   resources :items
   resources :carts, only: [:create]
-
   resources :users, only: [:index, :create, :edit] do
     # resources :orders, only: [:index]
   end
-
 
   get '/profile', to: 'users#show'
   get '/profile/orders', to: 'orders#index'
@@ -26,6 +24,5 @@ Rails.application.routes.draw do
 
   get '/register', to: 'users#new'
   get '/merchants', to: 'users#index'
-
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/features/merchant_sees_own_dashboard_spec.rb
+++ b/spec/features/merchant_sees_own_dashboard_spec.rb
@@ -28,16 +28,6 @@ describe 'As a Merchant' do
     click_on 'View Items'
 
     expect(current_path).to eq('/dashboard/items')
-
     #did not test for expecting a user_cannot see this.
   end
-
-# Merchant's Items index page
-#
-# As a merchant
-# When I visit my dashboard
-# I see a link to view my own items
-# When I click that link
-# My URI route should be "/dashboard/items"
-
 end

--- a/spec/features/merchant_sees_own_dashboard_spec.rb
+++ b/spec/features/merchant_sees_own_dashboard_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-describe 'as a Merchant' do
+describe 'As a Merchant' do
   it 'displays the merchants own profile data on the dashboard, but cannot edit' do
     user = FactoryBot.create(:merchant)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-    visit "/dashboard/#{user.id}"
+    visit "/dashboard"
 
     expect(page).to have_content(user.name)
     expect(page).to have_content(user.email)
@@ -17,5 +17,27 @@ describe 'as a Merchant' do
     expect(page).to have_content(user.zip_code)
     expect(page).to have_no_link('Edit Profile')
   end
+
+  it 'When I visit my dashboard, I see a link to view my own items. When I click the link it navigates me to /dashboard/items' do
+    user = FactoryBot.create(:merchant)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit "/dashboard"
+
+    click_on 'View Items'
+
+    expect(current_path).to eq('/dashboard/items')
+
+    #did not test for expecting a user_cannot see this.
+  end
+
+# Merchant's Items index page
+#
+# As a merchant
+# When I visit my dashboard
+# I see a link to view my own items
+# When I click that link
+# My URI route should be "/dashboard/items"
 
 end

--- a/spec/features/user_sees_navigation_bar_spec.rb
+++ b/spec/features/user_sees_navigation_bar_spec.rb
@@ -33,8 +33,8 @@ describe 'as a registered user' do
         expect(page).to have_link("Browse", href: "/items" )
         expect(page).to have_link("Merchants", href: "/merchants")
         # expect(page).to have_css(".cart-button")
-        expect(page).to have_link("Profile", href: "/profile/#{user.id}")
-        expect(page).to have_link("Orders", href: user_orders_path(user.id))
+        expect(page).to have_link("Profile", href: "/profile")
+        expect(page).to have_link("Orders", href: profile_orders_path)
         expect(page).to have_link("Log Out", href: logout_path)
         expect(page).to have_content("Logged in as #{user.name}")
 
@@ -60,9 +60,9 @@ describe 'as a mercha t user' do
         expect(page).to have_link("Home", href: "/")
         expect(page).to have_link("Browse", href: "/items" )
         expect(page).to have_link("Merchants", href: "/merchants")
-        expect(page).to have_link("Profile", href: "/profile/#{merchant.id}")
-        expect(page).to have_link("Orders", href: user_orders_path(merchant.id))
-        expect(page).to have_link("Dashboard", href: "/dashboard/#{merchant.id}")
+        expect(page).to have_link("Profile", href: "/profile")
+        expect(page).to have_link("Orders", href: profile_orders_path)
+        expect(page).to have_link("Dashboard", href: "/dashboard")
         expect(page).to have_link("Log Out", href: logout_path)
         expect(page).to have_content("Logged in as #{merchant.name}")
 

--- a/spec/features/users_can_login_spec.rb
+++ b/spec/features/users_can_login_spec.rb
@@ -10,7 +10,7 @@ describe 'as a regular user' do
     fill_in :password, with: user.password
     click_on 'Log In'
 
-    expect(current_path).to eq(profile_path(user))
+    expect(current_path).to eq(profile_path)
     expect(page).to have_content("Welcome, #{user.name}")
   end
 end
@@ -25,7 +25,7 @@ describe 'as a merchant user' do
     fill_in :password, with: merchant.password
     click_on 'Log In'
 
-    expect(current_path).to eq("/dashboard/#{merchant.id}")
+    expect(current_path).to eq("/dashboard")
     expect(page).to have_content("Welcome, #{merchant.name}")
   end
 end
@@ -72,7 +72,7 @@ describe 'as a regular user' do
 
     visit login_path
 
-    expect(current_path).to eq(profile_path(user))
+    expect(current_path).to eq(profile_path)
     expect(page).to have_content("You are already logged in")
   end
 end
@@ -89,7 +89,7 @@ describe 'as a merchant user' do
 
     visit login_path
 
-    expect(current_path).to eq("/dashboard/#{merchant.id}")
+    expect(current_path).to eq("/dashboard")
     expect(page).to have_content("You are already logged in")
   end
 end


### PR DESCRIPTION
@iandouglas Hoping you could review this. It is not ready to be merged (if there is a more appropriate way to send this code to you, rather than making a pull request, please let me know).

Justin and I significantly altered our routes by removing the :id from the end of several routes and utilizing the current_user instead. We'd like to check-in about this code being on the right path, before making further changes.

User Story 41 (detailed below) requires the items link to navigate to  '/dashboard/items' . How can we alter the controller#action to navigate the user to the proper controller/method/view.
Here is the current route:
get '/dashboard/items', to: 'users#index'

The following routes are identical in terms of their controller#action, should they be combined in some way? If so how?
 get '/profile', to: 'users#show'
get '/dashboard', to: 'users#show'

-----------------------------------------------------------------------------------

[ ] done

User Story 41
Merchant's Items index page

As a merchant
When I visit my dashboard
I see a link to view my own items
When I click that link
My URI route should be "/dashboard/items"