### PR TITLE
Fixes Merchant Dashboard Order Index Page. Alters a Route.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,6 @@ class User < ApplicationRecord
   end
 
   def merchant_pending_orders
-   Order.joins(:items).select("orders.*").where("items.user_id=#{self.id}").where(orders: {status: :pending})
+    Order.joins(:items).select("orders.*").where("items.user_id=#{self.id}").where(orders: {status: :pending}).group(:id)
   end
 end

--- a/app/views/dashboard/orders/index.html.erb
+++ b/app/views/dashboard/orders/index.html.erb
@@ -1,5 +1,5 @@
 <% @orders.each do |order| %>
-  <h5>Order Id: <%= link_to order.id, "/dashboard/orders/#{order.id}" %></h5>
+  <h5>Order Id: <%= link_to order.id, dashboard_order_path(order) %></h5>
   Date Created: <%= order.created_at %>
   Quantity: <%= order.total_quantity %> items
   Price: $<%= order.total_price %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
     get '/items/new', to: 'items#new'
     get "/items/edit/:id", to: "items#edit", as: "item_edit"
     get "/orders", to: 'orders#index'
-    get "/orders/:id", to: "orders#show"
+    get "/orders/:id", to: "orders#show", as: "order"
     delete "/items/delete/:id", to: "items#destroy", as: "item"
     patch "/items/toggle/:id", to: "items#toggle", as: "item_toggle"
   end


### PR DESCRIPTION
Makes alteration in the Merchant Order Dashboard for pending orders, as a result of the orders being duplicated. The method needed a group attached to the end. Also alters the route in a view to utilize a path helper.