### PR TITLE
adds pending orders to merchant dashboard, moves from dashboard/orders

### DIFF
--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -1,6 +1,6 @@
 class Dashboard::OrdersController < ApplicationController
   def index
-    @orders = current_user.merchant_pending_orders
+    @orders = current_user.orders
   end
 
   def show

--- a/app/controllers/dashboard/users_controller.rb
+++ b/app/controllers/dashboard/users_controller.rb
@@ -1,5 +1,6 @@
 class Dashboard::UsersController < ApplicationController
   def show
     @user = current_user
+    @orders = current_user.merchant_pending_orders
   end
 end

--- a/app/views/dashboard/orders/_order_info.html.erb
+++ b/app/views/dashboard/orders/_order_info.html.erb
@@ -1,0 +1,4 @@
+<h5>Order Id: <%= link_to order.id, dashboard_order_path(order) %></h5>
+Date Created: <%= order.created_at %>
+Quantity: <%= order.total_quantity %> items
+Price: $<%= order.total_price %>

--- a/app/views/dashboard/orders/index.html.erb
+++ b/app/views/dashboard/orders/index.html.erb
@@ -1,6 +1,3 @@
 <% @orders.each do |order| %>
-  <h5>Order Id: <%= link_to order.id, dashboard_order_path(order) %></h5>
-  Date Created: <%= order.created_at %>
-  Quantity: <%= order.total_quantity %> items
-  Price: $<%= order.total_price %>
+  <%= render partial: "/dashboard/orders/order_info", locals: {order: order} %>
 <% end %>

--- a/app/views/dashboard/users/show.html.erb
+++ b/app/views/dashboard/users/show.html.erb
@@ -1,2 +1,6 @@
 <%= render partial: "/user_info" %>
 <%= link_to 'View Items', "/dashboard/items"%>
+<h3>Pending Orders</h3>
+<% @orders.each do |order| %>
+  <%= render partial: "/dashboard/orders/order_info", locals: {order: order} %>
+<% end %>

--- a/spec/features/merchant_sees_own_dashboard_spec.rb
+++ b/spec/features/merchant_sees_own_dashboard_spec.rb
@@ -62,7 +62,7 @@ describe 'As a Merchant' do
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-    visit dashboard_orders_path
+    visit dashboard_path
     expect(page).to have_link(order_2.id)
     expect(page).to have_content(order_2.created_at)
     expect(page).to have_content("Quantity: #{order_2.total_quantity}")


### PR DESCRIPTION
* Routes fix for user story:
#30 US 39
As a merchant
When I visit my dashboard ("/dashboard")
If any users have pending orders containing items I sell
Then I see a list of these orders.
Each order listed includes the following information:
- the ID of the order, which is a link to the order show page ("/dashboard/orders/15")
- the date the order was made
- the total quantity of my items in the order
- the total value of my items for that order

Needs to be on dashboard, not dashboard/orders

*all tests pass!