### PR TITLE
finishes story 35

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -269,11 +269,6 @@ label {
   margin: 10px;
   padding: 10px;
 }
-// .cart-item img {
-//   max-width: 250px;
-//   max-height: 300px;
-//   margin: 30px;
-// }
 
 #cart-item-title {
   font-size: 150%;
@@ -295,6 +290,11 @@ label {
 }
 
 #all-merchants {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.merchant-enable {
   display: flex;
   flex-wrap: wrap;
 }

--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -14,6 +14,8 @@ class Profile::OrdersController < ApplicationController
     order = Order.new(user: current_user, status: 'pending')
     if order.save
       order.add_cart(@cart)
+      session[:cart] = {}
+      @cart.empty_cart
       flash[:notice] = "Order created successfully"
       redirect_to profile_path
     else

--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -21,4 +21,11 @@ class Profile::OrdersController < ApplicationController
       redirect_to profile_path
     end
   end
+
+  def destroy
+    order = Order.find(params[:id])
+    order.cancel_order
+    flash[:message] = "Order cancelled"
+    redirect_to profile_path
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -24,4 +24,14 @@ class Order < ApplicationRecord
   def pending?
     status == 'pending'
   end
+
+  def cancel_order
+    order_items.each do |oi|
+      if oi.fulfilled == true
+        oi.item.update(instock_qty: (oi.quantity + oi.item.instock_qty))
+        oi.update(fulfilled: false)
+      end
+    end
+    update(status: 'cancelled')
+  end
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,13 +1,18 @@
-<% @users.each do |user| %>
-  <div id="user-<%=user.id%>">
-      <%= link_to(user.name, admin_user_path(user)) %> | Registered at <%= user.created_at.to_date %>
-      <p>Status: <%= user.status %>
+<div class='merchant-enable'>
+  <% @users.each do |user| %>
+    <div class='merchant-index'>
+      <div id="user-<%=user.id%>">
+          <h2><%= link_to(user.name, admin_user_path(user)) %></h2>
+          <p>Registered at <%= user.created_at.to_date %></p>
+          <p>Status: <%= user.status %>
 
-      <% if user.enabled? %>
-        <%= button_to("Disable", admin_disable_user_path(user), method: :patch) %>
-      <% else %>
-        <%= button_to("Enable", admin_enable_user_path(user), method: :patch) %>
-      <% end %>
-      </p>
-  </div>
-<% end %>
+          <% if user.enabled? %>
+            <%= button_to("Disable", admin_disable_user_path(user), method: :patch) %>
+          <% else %>
+            <%= button_to("Enable", admin_enable_user_path(user), method: :patch) %>
+          <% end %>
+          </p>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,6 +8,10 @@
     <li><b>Merchant Name:</b> <%= @item.user.name %></li>
     <li><b>Inventory:</b> <%= @item.instock_qty %></li>
     <li><strong>Price: </strong><%= number_to_currency(@item.price) %></li>
-    <li><%= button_to "Add Item", carts_path(item_id: @item.id) %></li>
+    <% unless current_user && (current_user.admin? || current_user.merchant?) %>
+      <li>
+        <%= button_to "Add Item", carts_path(item_id: @item.id) %>
+      </li>
+    <% end %>
   </ul>
 </div>

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -1,6 +1,10 @@
 <div class='order-show'>
 <h1><b>Order </b><%= @order.id %></h1>
-<h2><b>Status: </b><%= @order.status.titleize %> <% if @order.status == 'pending' %><%= link_to "Cancel Order", profile_order_path(@order), method: :delete %><% end %></h2>
+<h2><b>Status: </b><%= @order.status.titleize %>
+  <% if @order.status == 'pending' %>
+    <%= link_to "| Cancel Order?", profile_order_path(@order), method: :delete, data: {confirm: "Are you sure you want to cancel this order?"} %>
+  <% end %>
+</h2>
 <h2><b>Ordered on: </b><%= @order.created_at.to_date %></h2>
 <h2><b>Order updated on: </b><%= @order.updated_at.to_date %></h2>
   <div class="show-order">

--- a/app/views/profile/users/_user_order_summary.html.erb
+++ b/app/views/profile/users/_user_order_summary.html.erb
@@ -8,3 +8,6 @@
     <h4><b>Total:</b> <%= number_to_currency(order.total_price) %> </h4>
   </div>
 <% end %>
+<% if @user.orders.count == 0 %>
+  <h3>No open orders. Go buy some stuff!</h3>
+<% end %>

--- a/app/views/profile/users/show.html.erb
+++ b/app/views/profile/users/show.html.erb
@@ -1,3 +1,4 @@
 <%= render partial: "/user_info"%>
+<h2>Current open orders:</h2>
 <%= render partial: "profile/users/user_order_summary"%>
 <%= link_to 'Edit Profile', profile_edit_path %>

--- a/spec/features/user_sees_cart_show_page_spec.rb
+++ b/spec/features/user_sees_cart_show_page_spec.rb
@@ -133,7 +133,9 @@ describe 'as a visitor or registered user' do
 
       visit cart_path
       click_on 'Check out'
-
+      within 'nav' do
+        expect(page).to have_content("Cart(0)")
+      end
       expect(current_path).to eq(profile_path)
       expect(page).to have_content('Order created successfully')
       expect(Order.last.status).to eq('pending')

--- a/spec/features/user_sees_order_show_page_spec.rb
+++ b/spec/features/user_sees_order_show_page_spec.rb
@@ -69,10 +69,10 @@ describe 'As a user' do
         expect(oi.fulfilled).to eq(false)
       end
       expect(@order_1.status).to eq('cancelled')
-      item_1_stock_qty_after = Item.find(@order_1.order_items.last.item.id).instock_qty
+      item_1_stock_qty_after = Item.find(@order_1.order_items.first.item.id).instock_qty
       expect(item_1_stock_qty_after).to eq(item_1_expected_qty)
 
-      item_2_stock_qty_after =Item.find(@order_1.order_items.first.item.id).instock_qty
+      item_2_stock_qty_after =Item.find(@order_1.order_items.last.item.id).instock_qty
       expect(item_2_stock_qty_after).to eq(item_2_expected_qty)
 
       expect(current_path).to eq(profile_path)

--- a/spec/features/user_sees_order_show_page_spec.rb
+++ b/spec/features/user_sees_order_show_page_spec.rb
@@ -52,23 +52,35 @@ describe 'As a user' do
       expect(page).to have_content("Grand total: $#{@order_1.total_price}")
     end
 
-    xit 'can cancel order if it is still pending' do
-      #Justin is doing
+    it 'can cancel order if it is still pending' do
+      @order_1.order_items.first.update(fulfilled: true)
+      item_1_stock_qty_before = @order_1.order_items.first.item.instock_qty
+      item_1_order_item_qty = @order_1.order_items.first.quantity
+      item_1_expected_qty = item_1_stock_qty_before + item_1_order_item_qty
+
+      item_2_stock_qty_before = @order_1.order_items.last.item.instock_qty
+      item_2_expected_qty = item_2_stock_qty_before
+
       visit profile_order_path(@order_1)
-      #cancel order
-      expect(false).to eq(true)
 
-      #       As a registered user
-      # When I visit an order's show page
-      # If the order is still "pending", I see a button or link to cancel the order
-      # When I click the cancel button for an order, the following happens:
-      # - Each row in the "order items" table is given a status of "unfulfilled"
-      # - The order itself is given a status of "cancelled"
-      # - Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
-      # - I am returned to my profile page
-      # - I see a flash message telling me the order is now cancelled
-      # - And I see that this order now has an updated status of "cancelled"
+      click_on "| Cancel Order?"
+
+      @order_1.order_items.each do |oi|
+        expect(oi.fulfilled).to eq(false)
+      end
+      expect(@order_1.status).to eq('cancelled')
+      item_1_stock_qty_after = Item.find(@order_1.order_items.last.item.id).instock_qty
+      expect(item_1_stock_qty_after).to eq(item_1_expected_qty)
+
+      item_2_stock_qty_after =Item.find(@order_1.order_items.first.item.id).instock_qty
+      expect(item_2_stock_qty_after).to eq(item_2_expected_qty)
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("Order cancelled")
+
+      within(".order-#{@order_1.id}") do
+        expect(page).to have_content("Status: cancelled")
+      end
     end
-
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -66,5 +66,33 @@ RSpec.describe Order, type: :model do
       expect(order_2.pending?).to eq(false)
       expect(order_3.pending?).to eq(false)
     end
+
+    it '.cancel_order' do
+      item_1 = FactoryBot.create(:item)
+      item_2 = FactoryBot.create(:item)
+      item_3 = FactoryBot.create(:item)
+
+      item_1_pre_inv = item_1.instock_qty
+      item_2_pre_inv = item_2.instock_qty
+      item_3_pre_inv = item_3.instock_qty
+
+      order_1 = FactoryBot.create(:pending, items: [item_1,item_2,item_3])
+
+      item_1.order_items.first.update(price: 2, quantity: 3, fulfilled: false)
+      item_2.order_items.first.update(price: 3, quantity: 1, fulfilled: true)
+      item_3.order_items.first.update(price: 4, quantity: 5, fulfilled: false)
+
+      order_1.cancel_order
+
+      expect(order_1.status).to eq('cancelled')
+
+      expect(order_1.order_items[0].fulfilled).to eq(false)
+      expect(order_1.order_items[1].fulfilled).to eq(false)
+      expect(order_1.order_items[2].fulfilled).to eq(false)
+
+      expect(item_1.instock_qty).to eq(item_1_pre_inv)
+      expect(item_2.instock_qty).to eq(item_2_pre_inv + 1)
+      expect(item_3.instock_qty).to eq(item_3_pre_inv)
+    end
   end
 end


### PR DESCRIPTION
Cancelled orders now make all order items unfulfilled, and any fulfilled order items also increase the item instock quantity to reflect a returned item. Page also shows a flash message and the order status is cancelled.