### PR TITLE
7 59 merchant order show

### DIFF
--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -1,5 +1,10 @@
 class Dashboard::OrdersController < ApplicationController
 
+
   def show
+    @order = Order.find(params[:id])
+    @user = @order.user #customer
   end
+
+
 end

--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -4,6 +4,8 @@ class Dashboard::OrdersController < ApplicationController
   def show
     @order = Order.find(params[:id])
     @user = @order.user #customer
+
+    @order_items = current_user.my_order_items(@order)
   end
 
 

--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -1,7 +1,4 @@
 class Dashboard::OrdersController < ApplicationController
-  def index
-    @orders = current_user.orders
-  end
 
   def show
   end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,4 +1,8 @@
 class OrderItem < ApplicationRecord
+  # validates_presence_of :price, :quantity
+  # These would ideally be here (along with tests). Breaks Rspec for now
+  # Would need to be accompanied by perhaps a before_validation method on the model
+
   belongs_to :item
   belongs_to :order
 

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -2,6 +2,10 @@ class OrderItem < ApplicationRecord
   # validates_presence_of :price, :quantity
   # These would ideally be here (along with tests). Breaks Rspec for now
   # Would need to be accompanied by perhaps a before_validation method on the model
+  before_validation :ensure_quantity, :ensure_price
+
+
+
 
   belongs_to :item
   belongs_to :order
@@ -9,4 +13,16 @@ class OrderItem < ApplicationRecord
   def subtotal
     quantity * price
   end
+
+  private
+
+  def ensure_quantity
+    self.quantity ||= 1
+  end
+
+  def ensure_price
+    self.price ||= 1
+  end
+
+
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,11 +1,7 @@
 class OrderItem < ApplicationRecord
-  # validates_presence_of :price, :quantity
-  # These would ideally be here (along with tests). Breaks Rspec for now
-  # Would need to be accompanied by perhaps a before_validation method on the model
+  validates_presence_of :price, :quantity
+  # We could do on the database level by setting a default, but this works
   before_validation :ensure_quantity, :ensure_price
-
-
-
 
   belongs_to :item
   belongs_to :order
@@ -23,6 +19,5 @@ class OrderItem < ApplicationRecord
   def ensure_price
     self.price ||= 1
   end
-
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,10 @@ class User < ApplicationRecord
    enabled? ? "Enabled" : "Disabled"
   end
 
+  def my_order_items(order)
+    OrderItem.joins(:item).where(items: {user_id: self.id})
+  end
+
   def merchant_pending_orders
     Order.joins(:items).select("orders.*").where("items.user_id=#{self.id}").where(orders: {status: :pending}).group(:id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   end
 
   def my_order_items(order)
-    OrderItem.joins(:item).where(items: {user_id: self.id})
+    OrderItem.joins(:item).where(order: order, items: {user_id: self.id})
   end
 
   def merchant_pending_orders

--- a/app/views/_order_items.html.erb
+++ b/app/views/_order_items.html.erb
@@ -1,0 +1,13 @@
+<% @order_items.each_with_index do |order_item, i| %>
+  <div id="item-<%=order_item.item_id  %>" class='show-order-item'>
+    <h2><span id='item-number'>Item <%= i + 1 %>:</span></h2>
+      <%= image_tag(order_item.item.image, class: "thumb") %>
+      <ul>
+        <li><b>Name: </b><%= link_to "#{order_item.item.name.titleize}", item_path(order_item.item) %></li>
+        <li><b>Description: </b><%= order_item.item.description %></li>
+        <li><b>Quantity: </b><%= order_item.quantity %></li>
+        <li><b>Price: </b><%= number_to_currency(order_item.price) %></li>
+        <li><b>Subtotal: </b><%= number_to_currency(order_item.subtotal) %></li>
+      </ul>
+  </div>
+<% end %>

--- a/app/views/dashboard/orders/_order_info.html.erb
+++ b/app/views/dashboard/orders/_order_info.html.erb
@@ -1,4 +1,4 @@
-<h5>Order Id: <%= link_to order.id, dashboard_order_path(order) %></h5>
+<h3>Order Id: <%= link_to order.id, dashboard_order_path(order) %></h3>
 Date Created: <%= order.created_at %>
 Quantity: <%= order.total_quantity %> items
 Price: <%= number_to_currency(order.total_price) %>

--- a/app/views/dashboard/orders/index.html.erb
+++ b/app/views/dashboard/orders/index.html.erb
@@ -1,0 +1,3 @@
+<% @orders.each do |order| %>
+  <%= render partial: "/dashboard/orders/order_info" %>
+<% end %>

--- a/app/views/dashboard/orders/index.html.erb
+++ b/app/views/dashboard/orders/index.html.erb
@@ -1,3 +1,0 @@
-<% @orders.each do |order| %>
-  <%= render partial: "/dashboard/orders/order_info", locals: {order: order} %>
-<% end %>

--- a/app/views/dashboard/orders/show.html.erb
+++ b/app/views/dashboard/orders/show.html.erb
@@ -1,4 +1,7 @@
 <h1>Order <%= @order.id %></h1>
 
 <h2>Customer info:</h2>
-<%= render partial: "/user_info", locals: {}%>
+<%= render partial: "/user_info"%>
+<% @order_items.each do |order_item| %>
+  <div id="item-<%= order_item.item_id %>"></div>
+<% end %>

--- a/app/views/dashboard/orders/show.html.erb
+++ b/app/views/dashboard/orders/show.html.erb
@@ -2,6 +2,4 @@
 
 <h2>Customer info:</h2>
 <%= render partial: "/user_info"%>
-<% @order_items.each do |order_item| %>
-  <div id="item-<%= order_item.item_id %>"></div>
-<% end %>
+<%= render partial: "/order_items" %>

--- a/app/views/dashboard/orders/show.html.erb
+++ b/app/views/dashboard/orders/show.html.erb
@@ -1,0 +1,4 @@
+<h1>Order <%= @order.id %></h1>
+
+<h2>Customer info:</h2>
+<%= render partial: "/user_info", locals: {}%>

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -4,21 +4,7 @@
 <h2><b>Ordered on: </b><%= @order.created_at.to_date %></h2>
 <h2><b>Order updated on: </b><%= @order.updated_at.to_date %></h2>
   <div class="show-order">
-    <% @order_items.each_with_index do |order_item, i| %>
-      <div id="item-<%=order_item.item_id  %>" class='show-order-item'>
-        <h2><span id='item-number'>Item <%= i + 1 %>:</span></h2>
-        <%= image_tag(order_item.item.image, class: "big-picture") %>
-        <div class='order-item-description'>
-          <ul>
-            <li><b>Name: </b><%= link_to "#{order_item.item.name.titleize}", item_path(order_item.item) %></li>
-            <li><b>Description: </b><%= order_item.item.description %></li>
-            <li><b>Quantity: </b><%= order_item.quantity %></li>
-            <li><b>Price: </b><%= number_to_currency(order_item.price) %></li>
-            <li><b>Subtotal: </b><%= number_to_currency(order_item.subtotal) %></li>
-          </ul>
-        </div>
-      </div>
-    <% end %>
+    <%= render partial: "/order_items" %>
     <h2><b>Grand total: </b><%= number_to_currency(@order.total_price) %> </h2>
   </div>
 </div>

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -37,10 +37,30 @@ describe 'order show page' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
 
       visit dashboard_order_path(order)
-      save_and_open_page
       expect(page).to have_css("#item-#{item_1.id}")
       expect(page).to_not have_css("#item-#{item_2.id}")
       expect(page).to_not have_css("#item-#{item_3.id}")
+    end
+    it "shows each item's information" do
+      merchant = FactoryBot.create(:merchant)
+      item_1 = FactoryBot.create(:item)
+      item_2 = FactoryBot.create(:item)
+      merchant.items += [item_1, item_2]
+
+      order = FactoryBot.create(:order)
+
+      order_item_1 = FactoryBot.create(:order_item, item: item_1, order: order, price: 3, quantity: 1.50)
+      order_item_2 = FactoryBot.create(:order_item, item: item_2, order: order, price: 2.75, quantity: 10)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+      visit dashboard_order_path(order)
+      within "#item-#{item_1.id}" do
+        expect(page).to have_link(item_1.name, href: item_path(item_1))
+        expect(page).to have_content(item_1.description)
+        expect(page).to have_css("img[src='#{item_1.image}']")
+        expect(page).to have_content("Quantity: #{order_item_1.quantity}")
+        expect(page).to have_content("Price: $#{order_item_1.price}")
+        expect(page).to have_content("Subtotal: $#{order_item_1.subtotal}")
+      end
     end
   end
 

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+describe 'order show page' do
+  context 'as a merchant' do
+    it "shows the customer's name and address" do
+      merchant = FactoryBot.create(:merchant)
+      item = FactoryBot.create(:item)
+      merchant.items << item
+
+      customer = FactoryBot.create(:user)
+
+      order = FactoryBot.create(:order, items: [item], user: customer)
+
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+      visit dashboard_path
+      click_on "#{order.id}"
+      expect(current_path).to eq(dashboard_order_path(order))
+
+      expect(page).to have_content(customer.name)
+      expect(page).to have_content(customer.address)
+      expect(page).to have_content(customer.city)
+      expect(page).to have_content(customer.state)
+      expect(page).to have_content(customer.zip_code)
+    end
+    it 'shows my items and no others from the order' do
+      merchant = FactoryBot.create(:merchant)
+      item_1 = FactoryBot.create(:item)
+      item_2 = FactoryBot.create(:item)
+      merchant.items << item_1
+
+      customer = FactoryBot.create(:user)
+      order = FactoryBot.create(:order, items: [item_1, item_2], user: customer)
+
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+      visit dashboard_order_path(order)
+      expect(page).to have_css("item-#{item_1.id}")
+      expect(page).to_not have_css("item-#{item_2.id}")
+    end
+  end
+
+end
+
+
+
+# When I visit an order show page from my dashboard
+# I only see the items in the order that are being purchased from my inventory
+# I do not see any items in the order being purchased from other merchants
+# For each item, I see the following information:
+# - the name of the item, which is a link to my item's show page
+# - a small thumbnail of the item
+# - my price for the item
+# - the quantity the user wants to purchase

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -27,6 +27,7 @@ describe 'order show page' do
       merchant = FactoryBot.create(:merchant)
       item_1 = FactoryBot.create(:item)
       item_2 = FactoryBot.create(:item)
+      item_3 = FactoryBot.create(:item)
       merchant.items << item_1
 
       customer = FactoryBot.create(:user)
@@ -36,8 +37,10 @@ describe 'order show page' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
 
       visit dashboard_order_path(order)
-      expect(page).to have_css("item-#{item_1.id}")
-      expect(page).to_not have_css("item-#{item_2.id}")
+      save_and_open_page
+      expect(page).to have_css("#item-#{item_1.id}")
+      expect(page).to_not have_css("#item-#{item_2.id}")
+      expect(page).to_not have_css("#item-#{item_3.id}")
     end
   end
 

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -42,7 +42,7 @@ describe 'order show page' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
 
       visit dashboard_order_path(order)
-      save_and_open_page
+
       expect(page).to have_css('.show-order-item', count: 2)
       expect(page).to have_css("#item-#{item_1.id}")
       expect(page).to_not have_css("#item-#{item_2.id}")

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -23,17 +23,19 @@ describe 'order show page' do
       expect(page).to have_content(customer.state)
       expect(page).to have_content(customer.zip_code)
     end
-    it 'shows my items and no others from the ordero my other items' do
+    it 'shows my items and no others from the order, or my other items' do
       merchant = FactoryBot.create(:merchant)
       item_1 = FactoryBot.create(:item)
       item_2 = FactoryBot.create(:item)
       item_3 = FactoryBot.create(:item)
       item_4 = FactoryBot.create(:item)
+      item_5 = FactoryBot.create(:item)
 
-      merchant.items += [item_1, item_4]
+
+      merchant.items += [item_1, item_4, item_5]
 
       customer = FactoryBot.create(:user)
-      order = FactoryBot.create(:order, items: [item_1, item_2], user: customer)
+      order = FactoryBot.create(:order, items: [item_1, item_2, item_5], user: customer)
       FactoryBot.create(:order, items: [item_4], user: customer)
 
 
@@ -41,6 +43,7 @@ describe 'order show page' do
 
       visit dashboard_order_path(order)
       save_and_open_page
+      expect(page).to have_css('.show-order-item', count: 2)
       expect(page).to have_css("#item-#{item_1.id}")
       expect(page).to_not have_css("#item-#{item_2.id}")
       expect(page).to_not have_css("#item-#{item_3.id}")

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -23,23 +23,28 @@ describe 'order show page' do
       expect(page).to have_content(customer.state)
       expect(page).to have_content(customer.zip_code)
     end
-    it 'shows my items and no others from the order' do
+    it 'shows my items and no others from the ordero my other items' do
       merchant = FactoryBot.create(:merchant)
       item_1 = FactoryBot.create(:item)
       item_2 = FactoryBot.create(:item)
       item_3 = FactoryBot.create(:item)
-      merchant.items << item_1
+      item_4 = FactoryBot.create(:item)
+
+      merchant.items += [item_1, item_4]
 
       customer = FactoryBot.create(:user)
       order = FactoryBot.create(:order, items: [item_1, item_2], user: customer)
+      FactoryBot.create(:order, items: [item_4], user: customer)
 
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
 
       visit dashboard_order_path(order)
+      save_and_open_page
       expect(page).to have_css("#item-#{item_1.id}")
       expect(page).to_not have_css("#item-#{item_2.id}")
       expect(page).to_not have_css("#item-#{item_3.id}")
+      expect(page).to_not have_css("#item-#{item_4.id}")
     end
     it "shows each item's information" do
       merchant = FactoryBot.create(:merchant)

--- a/spec/features/merchant_sees_own_dashboard_spec.rb
+++ b/spec/features/merchant_sees_own_dashboard_spec.rb
@@ -25,9 +25,8 @@ describe 'As a Merchant' do
 
     visit dashboard_path
 
-    click_on 'View Items'
+    expect(page).to have_link('View Items', href: dashboard_items_path)
 
-    expect(current_path).to eq(dashboard_items_path)
   end
 
   it 'If any users have pending orders containing items I sell, then I see a list of these orders' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe User, type: :model do
       order_4 = FactoryBot.create(:fulfilled, items: [item_1, item_2])
 
       expect(user.merchant_pending_orders).to eq([order_2, order_5])
+
+    end
+    it '.my_order_items(order)' do
+      merchant = FactoryBot.create(:merchant)
+      item_1 = FactoryBot.create(:item)
+      item_2 = FactoryBot.create(:item)
+      FactoryBot.create(:item)
+      merchant.items << item_1
+
+      order = FactoryBot.create(:order, items: [item_1, item_2])
+
+      expect(merchant.my_order_items(order)).to eq(item_1.order_items)
     end
   end
 end


### PR DESCRIPTION
As a merchant
When I visit an order show page from my dashboard
I see the customer's name and address
I only the items in the order that are being purchased from my inventory
I do not see any items in the order being purchased from other merchants
For each item, I see the following information:
- the name of the item, which is a link to my item's show page
- a small thumbnail of the item
- my price for the item
- the quantity the user wants to purchase

* Completes User Story
* Mackenzie and I walked through it (and found an error :< ... fixed as well as the test)
* All tests passing!