### PR TITLE
Adminviewsusers

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,6 +3,7 @@ class Admin::UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    redirect_to admin_merchant_path(@user) if @user.role == "merchant" 
   end
 
   def merchant_show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,13 +3,17 @@ class Admin::UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    redirect_to admin_merchant_path(@user) if @user.role == "merchant" 
+    redirect_to admin_merchant_path(@user) if @user.role == "merchant"
   end
 
   def merchant_show
     @user = User.find(params[:id])
-    @orders = @user.merchant_pending_orders
-    render template: 'dashboard/users/show'
+    if @user.role == "registered"
+      redirect_to admin_user_path(@user)
+    else
+      @orders = @user.merchant_pending_orders
+      render template: 'dashboard/users/show'
+    end
   end
 
   def index

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,6 +5,12 @@ class Admin::UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  def merchant_show
+    @user = User.find(params[:id])
+    @orders = @user.merchant_pending_orders
+    render template: 'dashboard/users/show'
+  end
+
   def index
     @users = User.where(role: ["registered"])
   end

--- a/app/controllers/dashboard/users_controller.rb
+++ b/app/controllers/dashboard/users_controller.rb
@@ -1,6 +1,7 @@
 class Dashboard::UsersController < ApplicationController
   def show
     @user = current_user
-    @orders = current_user.merchant_pending_orders
+    @orders = @user.merchant_pending_orders
+    render template: 'dashboard/users/show'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'items#index'
   namespace :admin do
-    get 'merchants/:id', to: "users#show", as: "merchant"
+    get 'merchants/:id', to: "users#merchant_show", as: "merchant"
     get 'users/:id', to: "users#show", as: "user"
     get 'users', to: "users#index", as: "users"
     patch 'disable_user/:id', to: "users#update", as: "disable_user"

--- a/spec/features/admin_redirected_spec.rb
+++ b/spec/features/admin_redirected_spec.rb
@@ -1,21 +1,22 @@
 require "rails_helper"
 describe 'as an admin' do
-  it 'I am redirected from user show to merchant dashboard' do
+  before(:each) do
     admin = FactoryBot.create(:admin)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+  end
+  it 'I am redirected from user show to merchant dashboard' do
 
     merchant = FactoryBot.create(:merchant)
-
     visit "/admin/users/#{merchant.id}"
 
-
     expect(current_path).to eq(admin_merchant_path(merchant))
+  end
+  it 'I am redirected from merchant dashboard to user show' do
 
-#     As an admin user
-# If I visit a profile page for a user, but that user is a merchant
-# Then I am redirected to the appropriate merchant dashboard page.
-# eg, if I visit "/admin/users/7" but that user is a merchant
-# Then I am redirected to "/admin/merchants/7"
-# And I see their merchant dashboard page
+    user = FactoryBot.create(:user)
+    visit "/admin/merchants/#{user.id}"
+
+    expect(current_path).to eq(admin_user_path(user))
+
   end
 end

--- a/spec/features/admin_redirected_spec.rb
+++ b/spec/features/admin_redirected_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 describe 'as an admin' do
-  xit 'I am redirected from user show to merchant show if user is a merchant' do
+  it 'I am redirected from user show to merchant dashboard' do
     admin = FactoryBot.create(:admin)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 

--- a/spec/features/admin_redirected_spec.rb
+++ b/spec/features/admin_redirected_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+describe 'as an admin' do
+  xit 'I am redirected from user show to merchant show if user is a merchant' do
+    admin = FactoryBot.create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    merchant = FactoryBot.create(:merchant)
+
+    visit "/admin/users/#{merchant.id}"
+
+
+    expect(current_path).to eq(admin_merchant_path(merchant))
+
+#     As an admin user
+# If I visit a profile page for a user, but that user is a merchant
+# Then I am redirected to the appropriate merchant dashboard page.
+# eg, if I visit "/admin/users/7" but that user is a merchant
+# Then I am redirected to "/admin/merchants/7"
+# And I see their merchant dashboard page
+  end
+end

--- a/spec/features/admin_redirected_spec.rb
+++ b/spec/features/admin_redirected_spec.rb
@@ -10,6 +10,8 @@ describe 'as an admin' do
     visit "/admin/users/#{merchant.id}"
 
     expect(current_path).to eq(admin_merchant_path(merchant))
+    expect(page).to have_content("Pending Orders")
+    
   end
   it 'I am redirected from merchant dashboard to user show' do
 

--- a/spec/features/admin_sees_merchant_show_spec.rb
+++ b/spec/features/admin_sees_merchant_show_spec.rb
@@ -14,6 +14,9 @@ describe "as an admin" do
     expect(current_path).to eq(admin_merchant_path(merchant))
     expect(page).to have_content(merchant.name)
     expect(page).to have_content(merchant.email)
+    expect(page).to have_content("Pending Orders")
+    expect(page).to have_link("View Items")
+    #link won't work yet
   end
 end
 describe "as a visitor" do

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -42,7 +42,7 @@ describe 'order show page' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
 
       visit dashboard_order_path(order)
-      save_and_open_page
+      
       expect(page).to have_css('.show-order-item', count: 2)
       expect(page).to have_css("#item-#{item_1.id}")
       expect(page).to_not have_css("#item-#{item_2.id}")


### PR DESCRIPTION
Fixes previous misinterpretation of user story 42:

As an admin user
When I visit the merchant index page ("/merchants")
And I click on a merchant's name,
Then my URI route should be ("/admin/merchants/6")
Then I see everything that merchant would see

"Everything a merchant would see" is the dashboard, not just the user info
*** Feature could be more complete if clicking on the items would bring up the items for that merchant (which now won't work because the merchant isn't the current user), but the user story did not specify.


Finishes User story  25:

As an admin user
If I visit a profile page for a user, but that user is a merchant
Then I am redirected to the appropriate merchant dashboard page.
eg, if I visit "/admin/users/7" but that user is a merchant
Then I am redirected to "/admin/merchants/7"
And I see their merchant dashboard page

and 44: 

As an admin user
If I visit a merchant dashboard, but that merchant is a regular user
Then I am redirected to the appropriate user profile page.

eg, if I visit "/admin/merchants/7" but that merchant is a regular user
then I am redirected to "/admin/users/7" and see their user profile page
