### PR TITLE
Average item time

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,4 +13,13 @@ class Item < ApplicationRecord
   def never_ordered?
     order_items.empty?
   end
+
+  def avg_fulfillment_time
+    results = OrderItem.select("avg(updated_at - created_at) as avg_f_time").where(item: self, fulfilled: true)
+    if results.present?
+      return results.first['avg_f_time']
+    else
+      return nil
+    end
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,7 +10,7 @@
     <li><strong>Price: </strong><%= number_to_currency(@item.price) %></li>
     <li><strong>Average Time to Fulfill Item: </strong>
     <% if avg_time = @item.avg_fulfillment_time %>
-      <%= avg_time[0..-8] %>
+      <%= avg_time.sub(/\.\d*$/, '') %>
     <% end %>
     </li>
     <% unless current_user && (current_user.admin? || current_user.merchant?) %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,6 +8,11 @@
     <li><b>Merchant Name:</b> <%= @item.user.name %></li>
     <li><b>Inventory:</b> <%= @item.instock_qty %></li>
     <li><strong>Price: </strong><%= number_to_currency(@item.price) %></li>
+    <li><strong>Average Time to Fulfill Item: </strong>
+    <% if avg_time = @item.avg_fulfillment_time %>
+      <%= avg_time[0..-8] %>
+    <% end %>
+    </li>
     <% unless current_user && (current_user.admin? || current_user.merchant?) %>
       <li>
         <%= button_to "Add Item", carts_path(item_id: @item.id) %>

--- a/spec/features/user_can_see_an_item_show_page_spec.rb
+++ b/spec/features/user_can_see_an_item_show_page_spec.rb
@@ -6,6 +6,15 @@ require 'rails_helper'
 describe "user sees an item" do
   it "user sees item attributes" do
     item_1 = FactoryBot.create(:item)
+    user_1 = FactoryBot.create(:user)
+    order_1 = item_1.orders.create(user: user_1)
+    order_2 = item_1.orders.create(user: user_1)
+    unfulfilled_order = item_1.orders.create(user: user_1)
+
+    order_1.order_items.first.update(fulfilled: true, created_at: 0.4.hours.ago)
+    order_2.order_items.first.update(fulfilled: true, created_at: 3.days.ago)
+    unfulfilled_order.order_items.first.update(fulfilled: false, created_at: 21.days.ago)
+
     item_2 = FactoryBot.create(:item)
 
     visit item_path(item_1)
@@ -16,6 +25,7 @@ describe "user sees an item" do
     expect(page).to have_content(item_1.instock_qty)
     expect(page).to have_content(item_1.description)
     expect(page).to have_content(item_1.user.name)
+    expect(page).to have_content("Average Time to Fulfill Item: 1 day 12:12:00")
 
     expect(page).to_not have_content(item_2.name)
   end

--- a/spec/features/user_sees_order_show_page_spec.rb
+++ b/spec/features/user_sees_order_show_page_spec.rb
@@ -69,10 +69,10 @@ describe 'As a user' do
         expect(oi.fulfilled).to eq(false)
       end
       expect(@order_1.status).to eq('cancelled')
-      item_1_stock_qty_after = Item.find(@order_1.order_items.first.item.id).instock_qty
+      item_1_stock_qty_after = Item.find(@order_1.order_items.last.item.id).instock_qty
       expect(item_1_stock_qty_after).to eq(item_1_expected_qty)
 
-      item_2_stock_qty_after =Item.find(@order_1.order_items.last.item.id).instock_qty
+      item_2_stock_qty_after =Item.find(@order_1.order_items.first.item.id).instock_qty
       expect(item_2_stock_qty_after).to eq(item_2_expected_qty)
 
       expect(current_path).to eq(profile_path)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Item, type: :model do
       order_1.order_items.first.update(fulfilled: true, created_at: 0.4.hours.ago)
       order_2.order_items.first.update(fulfilled: true, created_at: 3.days.ago)
       unfulfilled_order.order_items.first.update(fulfilled: false, created_at: 21.days.ago)
-      expect(item_1.avg_fulfillment_time[0..-8]).to eq("1 day 12:12:00")
+      expect(item_1.avg_fulfillment_time.sub(/\.\d*$/, '')).to eq("1 day 12:12:00")
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -22,5 +22,17 @@ RSpec.describe Item, type: :model do
       expect(item_1.never_ordered?).to eq(true)
       expect(item_2.never_ordered?).to eq(false)
     end
+    it '.avg_fulfillment_time' do
+      item_1 = FactoryBot.create(:item)
+      user_1 = FactoryBot.create(:user)
+      order_1 = item_1.orders.create(user: user_1)
+      order_2 = item_1.orders.create(user: user_1)
+      unfulfilled_order = item_1.orders.create(user: user_1)
+
+      order_1.order_items.first.update(fulfilled: true, created_at: 0.4.hours.ago)
+      order_2.order_items.first.update(fulfilled: true, created_at: 3.days.ago)
+      unfulfilled_order.order_items.first.update(fulfilled: false, created_at: 21.days.ago)
+      expect(item_1.avg_fulfillment_time[0..-8]).to eq("1 day 12:12:00")
+    end
   end
 end


### PR DESCRIPTION
Implements displaying average time to fulfill item to fulfill item per User Story 16.
Time is currently displayed as:

"3 days 04:20:04"

for example. 

five minutes would be:

"00:05:00"

Whether or not this is readable enough, I'm not sure. I've asked Ian. No response yet