### PR TITLE
Admin cancels order

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,10 +1,10 @@
 class Admin::ItemsController < ApplicationController
+  before_action :require_admin
+
   def new
     @merchant = User.find(params[:merchant_id])
     @item = Item.new
   end
-
-
 
   def create
     @merchant = User.find(params[:merchant_id])

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,5 @@
+class Admin::OrdersController < ApplicationController
+  def show
+    reder template: 
+  end
+end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,5 +1,17 @@
 class Admin::OrdersController < ApplicationController
+  before_action :require_admin
   def show
-    reder template: 
+    @order = Order.find(params[:id])
+    @order_items = @order.order_items
+    @user = @order.user
+    @cancel_order_path = :admin_order_path
+    render template: "profile/orders/show"
+  end
+  def destroy
+    order = Order.find(params[:id])
+    @user = order.user
+    order.cancel_order
+    flash[:message] = "Order cancelled"
+    redirect_to admin_user_path(@user)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def require_admin
+    render file: "/public/404", status: :not_found unless admin_user?
+  end
+
   def add_errors_on_flash(object_with_errors)
     object_with_errors.errors.each do |attribute, message|
       flash[attribute] = "#{error_prefix[object_with_errors.class.to_s]} #{attribute} #{message}."

--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -1,10 +1,11 @@
 class Profile::OrdersController < ApplicationController
   before_action :require_current_user
-  
+
   def show
     @order = Order.find(params[:id])
     @user = current_user
     @order_items = @order.order_items
+    @cancel_order_path = :profile_order_path
   end
 
   def index

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -2,7 +2,7 @@
 <h1><b>Order </b><%= @order.id %></h1>
 <h2><b>Status: </b><%= @order.status.titleize %>
   <% if @order.status == 'pending' %>
-    <%= link_to "| Cancel Order?", profile_order_path(@order), method: :delete, data: {confirm: "Are you sure you want to cancel this order?"} %>
+    <%= link_to "| Cancel Order?", send(@cancel_order_path, @order), method: :delete, data: {confirm: "Are you sure you want to cancel this order?"} %>
   <% end %>
 </h2>
 <h2><b>Ordered on: </b><%= @order.created_at.to_date %></h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,11 @@ Rails.application.routes.draw do
     resources :merchants, only: [:none], shallow: true do
       resources :items, expect: [:show]
     end
-    patch 'items/toggle/:id', to: "items#toggle", as: "item_toggle", as: "item_toggle"
-    get 'merchants/:id', to: "users#merchant_show", as: "merchant"
     resources :users, only: [:show, :index, :edit, :update]
+    resources :orders, only: [:show]
+    patch 'items/toggle/:id', to: "items#toggle", as: "item_toggle", as: "item_toggle"
     patch 'users/toggle/:id', to: "users#toggle", as: "toggle_user"
+    get 'merchants/:id', to: "users#merchant_show", as: "merchant"
   end
 
   resources :items, only: [:show, :index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       resources :items, expect: [:show]
     end
     resources :users, only: [:show, :index, :edit, :update]
-    resources :orders, only: [:show]
+    resources :orders, only: [:show, :destroy]
     patch 'items/toggle/:id', to: "items#toggle", as: "item_toggle", as: "item_toggle"
     patch 'users/toggle/:id', to: "users#toggle", as: "toggle_user"
     get 'merchants/:id', to: "users#merchant_show", as: "merchant"

--- a/spec/features/admin_sees_order_show_page_spec.rb
+++ b/spec/features/admin_sees_order_show_page_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
-describe 'As a user' do
+describe 'As an admin' do
   before(:each) do
-    @user_1, @user_2 = FactoryBot.create_list(:user, 2)
+    @user_1 = FactoryBot.create(:user)
+    @admin_1 = FactoryBot.create(:admin)
     @merchant = FactoryBot.create(:merchant)
     @order_1 = @user_1.orders.create(status: 'pending')
 
@@ -15,13 +16,14 @@ describe 'As a user' do
     @order_item_1 = @item_1.order_items.first
     @order_1.order_items.last.update(price: 1, quantity: 2)
     @order_item_2 = @item_2.order_items.first
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
 
   end
-  describe "when I visit an order's show page" do
+  describe 'when I visit and orders show page' do
     it 'should show the order info and all of the order items' do
 
-      visit profile_order_path(@order_1)
+      visit admin_order_path(@order_1)
 
       expect(page).to have_content("Order #{@order_1.id}")
       expect(page).to have_content("Ordered on: #{@order_1.created_at.to_date}")

--- a/spec/features/admin_sees_order_show_page_spec.rb
+++ b/spec/features/admin_sees_order_show_page_spec.rb
@@ -17,7 +17,7 @@ describe 'As an admin' do
     @order_1.order_items.last.update(price: 1, quantity: 2)
     @order_item_2 = @item_2.order_items.first
 
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin_1)
 
   end
   describe 'when I visit and orders show page' do
@@ -63,21 +63,24 @@ describe 'As an admin' do
       item_2_stock_qty_before = @order_1.order_items.last.item.instock_qty
       item_2_expected_qty = item_2_stock_qty_before
 
-      visit profile_order_path(@order_1)
-
+      visit admin_order_path(@order_1)
       click_on "| Cancel Order?"
+
+      @order_1 = Order.find(@order_1.id)
 
       @order_1.order_items.each do |oi|
         expect(oi.fulfilled).to eq(false)
       end
       expect(@order_1.status).to eq('cancelled')
+
+      save_and_open_page
       item_1_stock_qty_after = Item.find(@item_1.id).instock_qty
       expect(item_1_stock_qty_after).to eq(item_1_expected_qty)
 
       item_2_stock_qty_after =Item.find(@item_2.id).instock_qty
       expect(item_2_stock_qty_after).to eq(item_2_expected_qty)
 
-      expect(current_path).to eq(profile_path)
+      expect(current_path).to eq(admin_user_path(@user_1))
       expect(page).to have_content("Order cancelled")
 
       within(".order-#{@order_1.id}") do

--- a/spec/features/admin_sees_order_show_page_spec.rb
+++ b/spec/features/admin_sees_order_show_page_spec.rb
@@ -73,7 +73,6 @@ describe 'As an admin' do
       end
       expect(@order_1.status).to eq('cancelled')
 
-      save_and_open_page
       item_1_stock_qty_after = Item.find(@item_1.id).instock_qty
       expect(item_1_stock_qty_after).to eq(item_1_expected_qty)
 

--- a/spec/features/user_permissions_spec.rb
+++ b/spec/features/user_permissions_spec.rb
@@ -11,6 +11,7 @@ describe 'as a visitor' do
               dashboard_order_path(1),
               admin_merchant_path(1),
               admin_user_path(1),
+              admin_order_path(1),
               admin_users_path ]
 
     paths.each do |path|
@@ -34,6 +35,7 @@ describe 'as a registered user' do
               dashboard_order_path(1),
               admin_merchant_path(1),
               admin_user_path(1),
+              admin_order_path(1),
               admin_users_path ]
 
     paths.each do |path|
@@ -55,6 +57,7 @@ describe 'as a merchant' do
               cart_path,
               admin_merchant_path(1),
               admin_user_path(1),
+              admin_order_path(1),
               admin_users_path ]
 
     paths.each do |path|
@@ -65,8 +68,8 @@ describe 'as a merchant' do
     end
   end
 end
-describe 'as a visitor' do
-  it 'should not be allowed to see admin, registered and merchant paths' do
+describe 'as a admin' do
+  it 'should not be allowed to see cart, registered and merchant paths' do
     admin = FactoryBot.create(:admin)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)

--- a/spec/features/user_sees_order_show_page_spec.rb
+++ b/spec/features/user_sees_order_show_page_spec.rb
@@ -65,6 +65,8 @@ describe 'As a user' do
 
       click_on "| Cancel Order?"
 
+      @order_1 = Order.find(@order_1.id)
+
       @order_1.order_items.each do |oi|
         expect(oi.fulfilled).to eq(false)
       end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Item, type: :model do
       order_1.order_items.first.update(fulfilled: true, created_at: 0.4.hours.ago)
       order_2.order_items.first.update(fulfilled: true, created_at: 3.days.ago)
       unfulfilled_order.order_items.first.update(fulfilled: false, created_at: 21.days.ago)
-      expect(item_1.avg_fulfillment_time.sub(/\.\d*$/, '')).to eq("1 day 12:12:00")
+      expect(item_1.avg_fulfillment_time).to include("1 day 12:12:00")
     end
   end
   describe 'class methods' do


### PR DESCRIPTION
Finishes User Story 36:

As an admin user
When I visit a user's order show page
If the order is still "pending", I see a button or link to cancel the order
When I click the cancel button for an order
The same behaviors happen as if the user canceled the order themselves

Mostly copied and modified code that was present for user.
Ensured a non-admin gets a 404 when trying to visit the admin pages.
All tests passing.