### PR TITLE
Tiny fixes

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -66,9 +66,7 @@ a {
 
 
  .dropdown {
-  position: relative;
   display: inline-block;
-
 }
 
 .dropdown:hover .dropdown-content {

--- a/app/views/_order_items.html.erb
+++ b/app/views/_order_items.html.erb
@@ -1,7 +1,7 @@
 <% @order_items.each_with_index do |order_item, i| %>
   <div id="item-<%=order_item.item_id  %>" class='show-order-item'>
     <h2><span id='item-number'>Item <%= i + 1 %>:</span></h2>
-      <%= image_tag(order_item.item.image, class: "thumb") %>
+      <%= image_tag(order_item.item.image, class: "thumb", onerror: 'this.src="/no_image_available.jpg"') %>
       <ul>
         <li><b>Name: </b><%= link_to "#{order_item.item.name.titleize}", item_path(order_item.item) %></li>
         <li><b>Description: </b><%= order_item.item.description %></li>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -9,7 +9,7 @@
     <div class='cart-basket'>
       <% @cart.current_items.each do |item| %>
         <div class='item-<%= item.id %> cart-item'>
-          <%= image_tag item.image, alt: item.name, class: :thumb %>
+          <%= image_tag item.image, alt: item.name, class: :thumb, onerror: 'this.src="/no_image_available.jpg"' %>
           <div class='cart-item-info'>
             <span id='cart-item-title'><h2><%= item.name %></h2></span>
             <h4>Sold by: <%= link_to "#{item.user.name}", merchants_path(item.user) %></h4>

--- a/app/views/dashboard/items/index.html.erb
+++ b/app/views/dashboard/items/index.html.erb
@@ -13,7 +13,7 @@
       <li><%= item.name %></li>
       <li><%= item.description %></li>
       <li>Price: <%= number_to_currency(item.price) %></li>
-      <li><%= image_tag(item.image, class: :thumb) %></li>
+      <li><%= image_tag(item.image, class: :thumb, onerror: 'this.src="/no_image_available.jpg"') %></li>
       <li>In stock: <%= item.instock_qty %></li>
     </ul>
     <% if merchant_user? %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -26,7 +26,7 @@
 <div class="flex-container">
   <% @items.each do |item| %>
     <div id="item-<%= item.id %>" class="inner-flex shadow">
-      <%= link_to image_tag(item.image, class: :thumb), item_path(item) %>
+      <%= link_to image_tag(item.image, class: :thumb, onerror: 'this.src="/no_image_available.jpg"'), item_path(item)%>
       <h4><%= link_to(item.name, item_path(item)) %></h4>
       <ul>
         <li><b>Sold by:</b> <%= item.user.name %> </li>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,7 +1,7 @@
 <div class='item-show-page'>
   <h1><%= @item.name %></h1>
   <div class="item-img">
-    <%= image_tag(@item.image, class: "big-picture") %>
+    <%= image_tag(@item.image, class: "big-picture", onerror: 'this.src="/no_image_available.jpg"') %>
   </div>
   <ul>
     <li><b>Description:</b> <%= @item.description %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     end
     resources :users, only: [:show, :index, :edit, :update]
     resources :orders, only: [:show, :destroy]
-    patch 'items/toggle/:id', to: "items#toggle", as: "item_toggle", as: "item_toggle"
+    patch 'items/toggle/:id', to: "items#toggle", as: "item_toggle"
     patch 'users/toggle/:id', to: "users#toggle", as: "toggle_user"
     get 'merchants/:id', to: "users#merchant_show", as: "merchant"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,7 +49,7 @@ end
   password = 'password'
   user = User.create(name: name, address: address, city: city, state: state, zip_code: zip_code, email: email, role: role, password: password, enabled: true)
   saved_names += "Normal user: Email #{email} password '#{password}'\n"
-  4.times do
+  rand(1..7).times do
     order = user.orders.create!(status: rand(0..2))
     order.items = merchants.sample(1)[0].items.sample(rand(2..8))
     order.order_items.each do |order_item|


### PR DESCRIPTION

Fixes 'Statistics' floating over nav bar in item index

Fixes duplicate as: in routes, was producing warning

In seeds, Users now have a variable number of orders for more realistic seeming stats.