### PR TITLE
User story 61

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -374,9 +374,7 @@ label {
     padding-bottom: 6px;
   }
 }
-.fulfill-button{
-  background-color: red;
-}
+
 .out-of-stock{
   background-color: red;
   font-weight: bold;

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -374,6 +374,15 @@ label {
     padding-bottom: 6px;
   }
 }
+.fulfill-button{
+  background-color: red;
+}
+.out-of-stock{
+  background-color: red;
+  font-weight: bold;
+  height: 50px;
+  padding-top: 25px;
+}
 
 .statistics {
   width: 540px;

--- a/app/views/_order_items.html.erb
+++ b/app/views/_order_items.html.erb
@@ -16,18 +16,22 @@
           <% end %></li>
         <li>
           <% if current_user && current_user.merchant? %>
+
             <% if order_item.fulfillable? %>
               <%= button_to 'Fulfill', dashboard_order_item_fulfill_path(order_item), method: 'patch' %>
-            <% elsif order_item OUT OF stock qty....%>
-              Out of Stock
+            <% elsif order_item.quantity <= order_item.item.instock_qty %>
+              <div class='Out_of_Stock'>Out of Stock</div>
             <% end %>
+
           <% elsif current_user && current_user.admin? %>
+
             <% if order_item.fulfillable? %>
               <%= button_to 'Fulfill', admin_order_item_fulfill_path(order_item), method: 'patch' %>
-            <% elsif order_item OUT OF stock qty....%>
-              Out of Stock
+            <% elsif order_item.quantity <= order_item.item.instock_qty %>
+              <div class='Out_of_Stock'>Out of Stock</div>
             <% end %>
-            <% end %>
+          <% end %>
+          
         </li>
       </ul>
   </div>

--- a/app/views/_order_items.html.erb
+++ b/app/views/_order_items.html.erb
@@ -19,7 +19,7 @@
 
             <% if order_item.fulfillable? %>
               <%= button_to 'Fulfill', dashboard_order_item_fulfill_path(order_item), method: 'patch' %>
-            <% elsif order_item.quantity <= order_item.item.instock_qty %>
+            <% elsif order_item.quantity > order_item.item.instock_qty %>
               <div class='Out_of_Stock'>Out of Stock</div>
             <% end %>
 
@@ -27,11 +27,11 @@
 
             <% if order_item.fulfillable? %>
               <%= button_to 'Fulfill', admin_order_item_fulfill_path(order_item), method: 'patch' %>
-            <% elsif order_item.quantity <= order_item.item.instock_qty %>
+            <% elsif order_item.quantity > order_item.item.instock_qty %>
               <div class='Out_of_Stock'>Out of Stock</div>
             <% end %>
           <% end %>
-          
+
         </li>
       </ul>
   </div>

--- a/app/views/_order_items.html.erb
+++ b/app/views/_order_items.html.erb
@@ -15,12 +15,18 @@
               <%= "Not Fulfilled" %>
           <% end %></li>
         <li>
-            <% if order_item.fulfillable? && merchant_user? || order_item.fulfillable? && admin_user?%>
-              <% if current_user && current_user.merchant? %>
-                <%= button_to 'Fulfill', dashboard_order_item_fulfill_path(order_item), method: 'patch' %>
-              <% elsif current_user && current_user.admin? %>
-                <%= button_to 'Fulfill', admin_order_item_fulfill_path(order_item), method: 'patch' %>
-              <% end %>
+          <% if current_user && current_user.merchant? %>
+            <% if order_item.fulfillable? %>
+              <%= button_to 'Fulfill', dashboard_order_item_fulfill_path(order_item), method: 'patch' %>
+            <% elsif order_item OUT OF stock qty....%>
+              Out of Stock
+            <% end %>
+          <% elsif current_user && current_user.admin? %>
+            <% if order_item.fulfillable? %>
+              <%= button_to 'Fulfill', admin_order_item_fulfill_path(order_item), method: 'patch' %>
+            <% elsif order_item OUT OF stock qty....%>
+              Out of Stock
+            <% end %>
             <% end %>
         </li>
       </ul>

--- a/app/views/_order_items.html.erb
+++ b/app/views/_order_items.html.erb
@@ -1,38 +1,36 @@
 <% @order_items.each_with_index do |order_item, i| %>
-  <div id="item-<%= order_item.item_id %>" class='show-order-item'>
-    <h2><span id='item-number'>Item <%= i + 1 %>:</span></h2>
-      <%= image_tag(order_item.item.image, class: "thumb", onerror: 'this.src="/no_image_available.jpg"') %>
-      <ul>
-        <li><b>Name: </b><%= link_to "#{order_item.item.name.titleize}", item_path(order_item.item) %></li>
-        <li><b>Description: </b><%= order_item.item.description %></li>
-        <li><b>Quantity: </b><%= order_item.quantity %></li>
-        <li><b>Price: </b><%= number_to_currency(order_item.price) %></li>
-        <li><b>Subtotal: </b><%= number_to_currency(order_item.subtotal) %></li>
-        <li><b>Status: </b>
-          <% if order_item.fulfilled? %>
-              <%= "Fulfilled" %>
-            <% else %>
-              <%= "Not Fulfilled" %>
-          <% end %></li>
-        <li>
-          <% if current_user && current_user.merchant? %>
-            <% if order_item.fulfillable? %>
-              <div class='fulfill-button'>
-                <%= button_to 'Fulfill', dashboard_order_item_fulfill_path(order_item), method: 'patch' %>
-              </div>
-            <% elsif order_item.quantity > order_item.item.instock_qty %>
-              <div class='out-of-stock'>Out of Stock</div>
-            <% end %>
-          <% elsif current_user && current_user.admin? %>
-            <% if order_item.fulfillable? %>
-              <div class='fulfill-button'>
+  <div class='order-item-container'>
+    <div id="item-<%= order_item.item_id %>" class='show-order-item'>
+      <h2><span id='item-number'>Item <%= i + 1 %>:</span></h2>
+        <%= image_tag(order_item.item.image, class: "thumb", onerror: 'this.src="/no_image_available.jpg"') %>
+        <ul>
+          <li><b>Name: </b><%= link_to "#{order_item.item.name.titleize}", item_path(order_item.item) %></li>
+          <li><b>Description: </b><%= order_item.item.description %></li>
+          <li><b>Quantity: </b><%= order_item.quantity %></li>
+          <li><b>Price: </b><%= number_to_currency(order_item.price) %></li>
+          <li><b>Subtotal: </b><%= number_to_currency(order_item.subtotal) %></li>
+          <li><b>Status: </b>
+            <% if order_item.fulfilled? %>
+                <%= "Fulfilled" %>
+              <% else %>
+                <%= "Not Fulfilled" %>
+            <% end %></li>
+          <li>
+            <% if current_user && current_user.merchant? %>
+              <% if order_item.fulfillable? %>
+                <%= button_to 'Fulfill', dashboard_order_item_fulfill_path(order_item), method: 'patch'%>
+              <% elsif order_item.quantity > order_item.item.instock_qty %>
+                <div class='out-of-stock'>Out of Stock</div>
+              <% end %>
+            <% elsif current_user && current_user.admin? %>
+              <% if order_item.fulfillable? %>
                 <%= button_to 'Fulfill', admin_order_item_fulfill_path(order_item), method: 'patch' %>
-              </div>
-            <% elsif order_item.quantity > order_item.item.instock_qty %>
-              <div class='out-of-stock'>Out of Stock</div>
+              <% elsif order_item.quantity > order_item.item.instock_qty %>
+                <div class='out-of-stock'>Out of Stock</div>
+              <% end %>
             <% end %>
-          <% end %>
-        </li>
-      </ul>
+          </li>
+        </ul>
+    </div>
   </div>
 <% end %>

--- a/app/views/_order_items.html.erb
+++ b/app/views/_order_items.html.erb
@@ -16,22 +16,22 @@
           <% end %></li>
         <li>
           <% if current_user && current_user.merchant? %>
-
             <% if order_item.fulfillable? %>
-              <%= button_to 'Fulfill', dashboard_order_item_fulfill_path(order_item), method: 'patch' %>
+              <div class='fulfill-button'>
+                <%= button_to 'Fulfill', dashboard_order_item_fulfill_path(order_item), method: 'patch' %>
+              </div>
             <% elsif order_item.quantity > order_item.item.instock_qty %>
-              <div class='Out_of_Stock'>Out of Stock</div>
+              <div class='out-of-stock'>Out of Stock</div>
             <% end %>
-
           <% elsif current_user && current_user.admin? %>
-
             <% if order_item.fulfillable? %>
-              <%= button_to 'Fulfill', admin_order_item_fulfill_path(order_item), method: 'patch' %>
+              <div class='fulfill-button'>
+                <%= button_to 'Fulfill', admin_order_item_fulfill_path(order_item), method: 'patch' %>
+              </div>
             <% elsif order_item.quantity > order_item.item.instock_qty %>
-              <div class='Out_of_Stock'>Out of Stock</div>
+              <div class='out-of-stock'>Out of Stock</div>
             <% end %>
           <% end %>
-
         </li>
       </ul>
   </div>

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -127,12 +127,12 @@ describe 'order show page' do
 
     it 'Shows a big red notice next to the item indicating I cannot fulfill this item' do
       merchant = FactoryBot.create(:merchant)
-      item_1 = FactoryBot.create(:item)
+      item_1 = FactoryBot.create(:item, instock_qty: 1)
       item_2 = FactoryBot.create(:item)
       merchant.items += [item_1, item_2]
       order = FactoryBot.create(:order)
 
-      order_item_1 = FactoryBot.create(:order_item, item: item_1, order: order, price: 3, quantity: 1.50)
+      order_item_1 = FactoryBot.create(:order_item, item: item_1, order: order, price: 3, quantity: 20)
       order_item_2 = FactoryBot.create(:order_item, item: item_2, order: order, price: 2.75, quantity: 10)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -147,8 +147,6 @@ describe 'order show page' do
         expect(page).to_not have_content("Out of Stock")
       end
     end
-
-    # REPEAT THE ABOVE TEST FOR A REGISTERED USER DOES NOT SEE THE NOTICE.
   end
 
   it 'A Registered User does not see the fulfill button' do

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -124,29 +124,5 @@ describe 'order show page' do
       expected_quantity = item_1.instock_qty - order_item_1.quantity
       expect(page).to have_content("Inventory: #{expected_quantity}")
     end
-
-    it 'Shows a big red notice next to the item indicating I cannot fulfill this item' do
-      merchant = FactoryBot.create(:merchant)
-      item_1 = FactoryBot.create(:item)
-      item_2 = FactoryBot.create(:item)
-      merchant.items += [item_1, item_2]
-      order = FactoryBot.create(:order)
-
-      order_item_1 = FactoryBot.create(:order_item, item: item_1, order: order, price: 3, quantity: 1.50)
-      order_item_2 = FactoryBot.create(:order_item, item: item_2, order: order, price: 2.75, quantity: 10)
-
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
-
-      visit dashboard_order_path(order)
-
-      # within "#item-#{order_item_1.item_id}" do
-      #   expect(page).to have_content("Status: Fulfilled")
-      # end
-
-      # within "#item-#{item_2.id}" do
-      #   click_on 'Fulfill'
-      # end
-      #
-    end
   end
 end

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -139,15 +139,13 @@ describe 'order show page' do
 
       visit dashboard_order_path(order)
 
-      # within "#item-#{order_item_1.item_id}" do
-      #   expect(page).to have_content("Status: Fulfilled")
-      # end
-
-      # within "#item-#{item_2.id}" do
-      #   click_on 'Fulfill'
-      # end
-      #
+      within "#item-#{order_item_1.item_id}" do
+        expect(page).to have_content("Out of Stock")
+      end
     end
+
+    # REPEAT THE ABOVE TEST FOR AS AN ADMIN.
+    # REPEAT THE ABOVE TEST FOR A REGISTERED USER DOES NOT SEE THE NOTICE.
   end
 
   it 'A Registered User does not see the fulfill button' do

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -124,21 +124,29 @@ describe 'order show page' do
       expected_quantity = item_1.instock_qty - order_item_1.quantity
       expect(page).to have_content("Inventory: #{expected_quantity}")
     end
+
+    it 'Shows a big red notice next to the item indicating I cannot fulfill this item' do
+      merchant = FactoryBot.create(:merchant)
+      item_1 = FactoryBot.create(:item)
+      item_2 = FactoryBot.create(:item)
+      merchant.items += [item_1, item_2]
+      order = FactoryBot.create(:order)
+
+      order_item_1 = FactoryBot.create(:order_item, item: item_1, order: order, price: 3, quantity: 1.50)
+      order_item_2 = FactoryBot.create(:order_item, item: item_2, order: order, price: 2.75, quantity: 10)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+      visit dashboard_order_path(order)
+
+      # within "#item-#{order_item_1.item_id}" do
+      #   expect(page).to have_content("Status: Fulfilled")
+      # end
+
+      # within "#item-#{item_2.id}" do
+      #   click_on 'Fulfill'
+      # end
+      #
+    end
   end
 end
-
-# As a merchant
-# When I visit an order show page from my dashboard
-# For each item of mine in the order
-# If the user's desired quantity is equal to or less than my current inventory quantity for that item
-# And I have not already "fulfilled" that item:
-# - Then I see a button or link to "fulfill" that item
-# - When I click on that link or button I am returned to the order show page
-# >>>>>>
-# - I see the item is now fulfilled
-# - I also see a flash message indicating that I have fulfilled that item
-# If I have already fulfilled this item, I see text indicating such.
-# >>>>>>>>>>>>>>>
-
-# - My inventory quantity is permanently reduced by the user's desired quantity
-#

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -128,7 +128,7 @@ describe 'order show page' do
     it 'Shows a big red notice next to the item indicating I cannot fulfill this item' do
       merchant = FactoryBot.create(:merchant)
       item_1 = FactoryBot.create(:item, instock_qty: 1)
-      item_2 = FactoryBot.create(:item)
+      item_2 = FactoryBot.create(:item, instock_qty: 500)
       merchant.items += [item_1, item_2]
       order = FactoryBot.create(:order)
 
@@ -142,9 +142,12 @@ describe 'order show page' do
       within "#item-#{order_item_1.item_id}" do
         expect(page).to have_content("Out of Stock")
       end
+
+      within "#item-#{order_item_2.item_id}" do
+        expect(page).to_not have_content("Out of Stock")
+      end
     end
 
-    # REPEAT THE ABOVE TEST FOR AS AN ADMIN.
     # REPEAT THE ABOVE TEST FOR A REGISTERED USER DOES NOT SEE THE NOTICE.
   end
 
@@ -218,5 +221,29 @@ describe 'order show page' do
 
     expected_quantity = item_1.instock_qty - order_item_1.quantity
     expect(page).to have_content("Inventory: #{expected_quantity}")
+  end
+
+  it 'For an Admin, shows a big red notice next to the item indicating I cannot fulfill this item' do
+    admin = FactoryBot.create(:admin)
+    merchant = FactoryBot.create(:merchant)
+    item_1 = FactoryBot.create(:item, instock_qty: 1)
+    item_2 = FactoryBot.create(:item, instock_qty: 500)
+    merchant.items += [item_1, item_2]
+    order = FactoryBot.create(:order)
+
+    order_item_1 = FactoryBot.create(:order_item, item: item_1, order: order, price: 3, quantity: 20)
+    order_item_2 = FactoryBot.create(:order_item, item: item_2, order: order, price: 2.75, quantity: 10)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit admin_order_path(order)
+
+    within "#item-#{order_item_1.item_id}" do
+      expect(page).to have_content("Out of Stock")
+    end
+
+    within "#item-#{order_item_2.item_id}" do
+      expect(page).to_not have_content("Out of Stock")
+    end
   end
 end

--- a/spec/features/merchant_sees_an_order_show_page_spec.rb
+++ b/spec/features/merchant_sees_an_order_show_page_spec.rb
@@ -124,5 +124,29 @@ describe 'order show page' do
       expected_quantity = item_1.instock_qty - order_item_1.quantity
       expect(page).to have_content("Inventory: #{expected_quantity}")
     end
+    
+    it 'Shows a big red notice next to the item indicating I cannot fulfill this item' do
+      merchant = FactoryBot.create(:merchant)
+      item_1 = FactoryBot.create(:item)
+      item_2 = FactoryBot.create(:item)
+      merchant.items += [item_1, item_2]
+      order = FactoryBot.create(:order)
+
+      order_item_1 = FactoryBot.create(:order_item, item: item_1, order: order, price: 3, quantity: 1.50)
+      order_item_2 = FactoryBot.create(:order_item, item: item_2, order: order, price: 2.75, quantity: 10)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+      visit dashboard_order_path(order)
+
+      # within "#item-#{order_item_1.item_id}" do
+      #   expect(page).to have_content("Status: Fulfilled")
+      # end
+
+      # within "#item-#{item_2.id}" do
+      #   click_on 'Fulfill'
+      # end
+      #
+    end
   end
 end


### PR DESCRIPTION
[X ] done

User Story 61
Merchant cannot fulfill an order due to lack of inventory

As a merchant
When I visit an order show page from my dashboard
For each item of mine in the order
If the user's desired quantity is greater than my current inventory quantity for that item
Then I do not see a "fulfill" button or link
Instead I see a big red notice next to the item indicating I cannot fulfill this item