### PR TITLE
Fixes cart viewing error

### DIFF
--- a/app/views/_navbar.html.erb
+++ b/app/views/_navbar.html.erb
@@ -23,7 +23,7 @@
       <% unless merchant_user? || admin_user? %>
         <li>
           <h3>
-            <%= button_to "cart", method: "get", html: {class: "cart-button"} do  %>
+            <%= button_to "/cart", method: "get", html: {class: "cart-button"} do  %>
               <div>
                 <i class="fas fa-shopping-cart"></i>
               </div>

--- a/spec/features/user/user_navigates_to_cart_from_orders_spec.rb
+++ b/spec/features/user/user_navigates_to_cart_from_orders_spec.rb
@@ -1,0 +1,18 @@
+#This is testing a bug fix
+
+require "rails_helper"
+
+describe 'as a logged in user' do
+  it 'I can navigate to my cart from by order index' do
+    user = FactoryBot.create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    visit "/"
+    within "nav" do
+      click_on "Orders"
+    end
+    within "nav" do
+      click_on "Cart"
+    end
+    expect(current_path).to eq("/cart")
+  end
+end


### PR DESCRIPTION
Because the button_to had a block, it was expecting the first argument to be the path and not the name. Was able to fix by adding a "/". Also wrote a test just in case this somehow gets overwritten in a merge conflict.